### PR TITLE
added visualizer using HSV colormap to utilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,13 +26,14 @@ set(MAIN_SOURCES
     OpticalFlow/circularBuffer.cpp
     OpticalFlow/convolution.cpp
     OpticalFlow/kernel.cpp
-    OpticalFlow/spatialConvolution.cpp
-    OpticalFlow/temporalConvolution.cpp
-    OpticalFlow/spatialConvolution.cu
-    OpticalFlow/temporalConvolution.cu
-    OpticalFlow/profiler.cu
 	OpticalFlow/least_squares_solver.cpp
 	OpticalFlow/least_squares_solver_cuda.cu
+    OpticalFlow/profiler.cu
+    OpticalFlow/spatialConvolution.cpp
+    OpticalFlow/spatialConvolution.cu
+    OpticalFlow/temporalConvolution.cpp
+    OpticalFlow/temporalConvolution.cu
+	OpticalFlow/utilities.cpp
 )
 
 set(MAIN_HEADERS
@@ -40,11 +41,12 @@ set(MAIN_HEADERS
     OpticalFlow/collection_adapters.hpp
     OpticalFlow/convolution.h
     OpticalFlow/kernel.h
-    OpticalFlow/spatialConvolution.h
-    OpticalFlow/temporalConvolution.h
-    OpticalFlow/profiler.h
 	OpticalFlow/least_squares_solver.h
 	OpticalFlow/least_squares_solver_cuda.h
+    OpticalFlow/profiler.h
+    OpticalFlow/spatialConvolution.h
+    OpticalFlow/temporalConvolution.h
+	OpticalFlow/utilities.h
 )
 
 set(CUDA_SOURCES

--- a/OpticalFlow/driverCPU.cu
+++ b/OpticalFlow/driverCPU.cu
@@ -5,12 +5,13 @@ Changes to make prior to GPU implementation
 * Use cv::cuda::GpuMat instead of cv::Mat
 
 */
-#include "profiler.h"
+#include "collection_adapters.hpp"
 #include "least_squares_solver.h"
+#include "least_squares_solver_cuda.h"
+#include "profiler.h"
 #include "spatialConvolution.h"
 #include "temporalConvolution.h"
-#include "collection_adapters.hpp"
-#include "least_squares_solver_cuda.h"
+#include "utilities.h"
 
 #include <Eigen/Dense>
 
@@ -166,7 +167,7 @@ int main(int argc, char* argv[]) {
         if (!cpuI_x.empty() && !cpuI_y.empty() && !cpuI_t.empty()) {
             //solver.computeOpticalFlow(I_x_32F, I_y_32F, I_t_32F, flowX, flowY);
 			solverCUDA.computeOpticalFlow(cpuI_x, cpuI_y, cpuI_t, flowX, flowY);
-            // Declare what you need
+
             imwrite("flowX_" + std::to_string(index) + ".jpg", flowX);
             imwrite("flowY_" + std::to_string(index) + ".jpg", flowY);
 
@@ -178,11 +179,15 @@ int main(int argc, char* argv[]) {
             resultsFile << "flowY Minimum value: " << minVal << " at position " << minLoc << std::endl;
             resultsFile << "flowY Maximum value: " << maxVal << " at position " << maxLoc << std::endl;
 
+            Mat bgr;
+            convertFlowToColorMap(flowX, flowY, bgr);
+
             flowX.convertTo(flowX_8u, CV_8U); // Convert to 8-bit
             flowY.convertTo(flowY_8u, CV_8U); // Convert to 8-bit
 
             rec.log("&.flowX", rerun::Image::from_greyscale8(flowX_8u, { uint32_t(flowX_8u.cols), uint32_t(flowX_8u.rows) }));
             rec.log("&.flowY", rerun::Image::from_greyscale8(flowY_8u, { uint32_t(flowY_8u.cols), uint32_t(flowY_8u.rows) }));
+            rec.log("9.OpticalFlow", rerun::Image::from_rgb24(bgr, { uint32_t(bgr.cols), uint32_t(bgr.rows) }));
             index++;
         }
     }

--- a/OpticalFlow/driverGPU.cu
+++ b/OpticalFlow/driverGPU.cu
@@ -5,12 +5,13 @@ Changes to make prior to GPU implementation
 * Use cv::cuda::GpuMat instead of cv::Mat
 
 */
+#include "collection_adapters.hpp"
 #include "profiler.h"
 #include "least_squares_solver.h"
+#include "least_squares_solver_cuda.h"
 #include "spatialConvolution.h"
 #include "temporalConvolution.h"
-#include "collection_adapters.hpp"
-#include "least_squares_solver_cuda.h"
+#include "utilities.h"
 
 #include <Eigen/Dense>
 
@@ -175,7 +176,7 @@ int main(int argc, char* argv[]) {
             if (!gpuNaiveI_x.empty() && !gpuNaiveI_y.empty() && !gpuNaiveI_t.empty()) {
                 //solver.computeOpticalFlow(I_x_32F, I_y_32F, I_t_32F, flowX, flowY);
                 solverCUDA.computeOpticalFlow(gpuNaiveI_x, gpuNaiveI_y, gpuNaiveI_t, flowX, flowY);
-                // Declare what you need
+
                 imwrite("flowX_" + std::to_string(index) + ".jpg", flowX);
                 imwrite("flowY_" + std::to_string(index) + ".jpg", flowY);
 
@@ -187,15 +188,18 @@ int main(int argc, char* argv[]) {
                 resultsFile << "flowY Minimum value: " << minVal << " at position " << minLoc << std::endl;
                 resultsFile << "flowY Maximum value: " << maxVal << " at position " << maxLoc << std::endl;
 
+                Mat bgr;
+                convertFlowToColorMap(flowX, flowY, bgr);
+
                 flowX.convertTo(flowX_8u, CV_8U); // Convert to 8-bit
                 flowY.convertTo(flowY_8u, CV_8U); // Convert to 8-bit
 
-                rec.log("&.flowX", rerun::Image::from_greyscale8(flowX_8u, { uint32_t(flowX_8u.cols), uint32_t(flowX_8u.rows) }));
-                rec.log("&.flowY", rerun::Image::from_greyscale8(flowY_8u, { uint32_t(flowY_8u.cols), uint32_t(flowY_8u.rows) }));
+                rec.log("7.flowX", rerun::Image::from_greyscale8(flowX_8u, { uint32_t(flowX_8u.cols), uint32_t(flowX_8u.rows) }));
+                rec.log("8.flowY", rerun::Image::from_greyscale8(flowY_8u, { uint32_t(flowY_8u.cols), uint32_t(flowY_8u.rows) }));
+                rec.log("9.OpticalFlow", rerun::Image::from_rgb24(bgr, { uint32_t(bgr.cols), uint32_t(bgr.rows) }));
                 index++;
             }
         }
-
         capture.release();
     }
 

--- a/OpticalFlow/driverGPUSharedMem.cu
+++ b/OpticalFlow/driverGPUSharedMem.cu
@@ -5,12 +5,13 @@ Changes to make prior to GPU implementation
 * Use cv::cuda::GpuMat instead of cv::Mat
 
 */
+#include "collection_adapters.hpp"
 #include "profiler.h"
 #include "least_squares_solver.h"
+#include "least_squares_solver_cuda.h"
 #include "spatialConvolution.h"
 #include "temporalConvolution.h"
-#include "collection_adapters.hpp"
-#include "least_squares_solver_cuda.h"
+#include "utilities.h"
 
 #include <Eigen/Dense>
 
@@ -175,9 +176,7 @@ int main(int argc, char* argv[]) {
             resultsFile << "I_t Minimum value: " << minVal << " at position " << minLoc << std::endl;
             resultsFile << "I_t Maximum value: " << maxVal << " at position " << maxLoc << std::endl;
 
-            Mat I_x_32F;
-            Mat I_y_32F;
-            Mat I_t_32F;
+            Mat I_x_32F, I_y_32F, I_t_32F;
 
             normalize(gpuSharedMemI_x, I_x_32F, -1, 1, cv::NORM_MINMAX);
             I_x_32F.convertTo(I_x_32F, CV_32F);
@@ -189,7 +188,7 @@ int main(int argc, char* argv[]) {
             if (!gpuSharedMemI_x.empty() && !gpuSharedMemI_y.empty() && !gpuSharedMemI_t.empty()) {
                 //solver.computeOpticalFlow(I_x_32F, I_y_32F, I_t_32F, flowX, flowY);
                 solverCUDA.computeOpticalFlow(gpuSharedMemI_x, gpuSharedMemI_y, gpuSharedMemI_t, flowX, flowY);
-                // Declare what you need
+
                 imwrite("flowX_" + std::to_string(index) + ".jpg", flowX);
                 imwrite("flowY_" + std::to_string(index) + ".jpg", flowY);
 
@@ -201,11 +200,15 @@ int main(int argc, char* argv[]) {
                 resultsFile << "flowY Minimum value: " << minVal << " at position " << minLoc << std::endl;
                 resultsFile << "flowY Maximum value: " << maxVal << " at position " << maxLoc << std::endl;
 
+                Mat bgr;
+                convertFlowToColorMap(flowX, flowY, bgr);
+
                 flowX.convertTo(flowX_8u, CV_8U); // Convert to 8-bit
                 flowY.convertTo(flowY_8u, CV_8U); // Convert to 8-bit
 
-                rec.log("&.flowX", rerun::Image::from_greyscale8(flowX_8u, { uint32_t(flowX_8u.cols), uint32_t(flowX_8u.rows) }));
-                rec.log("&.flowY", rerun::Image::from_greyscale8(flowY_8u, { uint32_t(flowY_8u.cols), uint32_t(flowY_8u.rows) }));
+                rec.log("7.flowX", rerun::Image::from_greyscale8(flowX_8u, { uint32_t(flowX_8u.cols), uint32_t(flowX_8u.rows) }));
+                rec.log("8.flowY", rerun::Image::from_greyscale8(flowY_8u, { uint32_t(flowY_8u.cols), uint32_t(flowY_8u.rows) }));
+                rec.log("9.OpticalFlow", rerun::Image::from_rgb24(bgr, { uint32_t(bgr.cols), uint32_t(bgr.rows) }));
                 index++;
             }
         }

--- a/OpticalFlow/utilities.cpp
+++ b/OpticalFlow/utilities.cpp
@@ -1,0 +1,27 @@
+#include "utilities.h"
+
+/**
+ * Converts optical flow vectors (flowX, flowY) to a color-coded visualization using HSV color mapping.
+ * The resulting image uses hue to represent direction and value (brightness) to represent magnitude.
+ */
+cv::Mat convertFlowToColorMap(const cv::Mat& flowX, const cv::Mat& flowY, cv::Mat& bgr) {
+    // Convert the algorithm's output into Polar coordinates
+    cv::Mat magnitude, angle, magn_norm;
+    cv::cartToPolar(flowX, flowY, magnitude, angle, true);
+    cv::normalize(magnitude, magn_norm, 0.0f, 1.0f, cv::NORM_MINMAX);
+    angle *= ((1.f / 360.f) * (180.f / 255.f));
+
+    // Build hsv image
+    cv::Mat _hsv[3], hsv, hsv8;
+    _hsv[0] = angle;
+    _hsv[1] = cv::Mat::ones(angle.size(), CV_32F);
+    _hsv[2] = magn_norm;
+    cv::merge(_hsv, 3, hsv);
+    cv::normalize(hsv, hsv, 0.0f, 1.0f, cv::NORM_MINMAX);
+    hsv.convertTo(hsv8, CV_8U, 255.0);
+
+    // Convert to BGR for display
+    cv::cvtColor(hsv8, bgr, cv::COLOR_HSV2BGR);
+    
+    return bgr;
+}

--- a/OpticalFlow/utilities.h
+++ b/OpticalFlow/utilities.h
@@ -1,0 +1,15 @@
+#ifndef UTILITIES_H
+#define UTILITIES_H
+
+#include <opencv2/opencv.hpp>
+
+/**
+ * Converts optical flow vectors (flowX, flowY) to a color-coded visualization using HSV color mapping.
+ * 
+ * @param flowX Matrix containing the x-component of the optical flow vectors
+ * @param flowY Matrix containing the y-component of the optical flow vectors
+ * @return Color-coded BGR image representing the flow vectors
+ */
+cv::Mat convertFlowToColorMap(const cv::Mat& flowX, const cv::Mat& flowY, cv::Mat&bgr);
+
+#endif // UTILITIES_H


### PR DESCRIPTION
# Summary
This feature takes the output of our leas squares solver to get flowX and flowY. These are the x and y components of the flow vector. The components are mapped to the HSV color space, where hue is the direction and saturation is the magnitude.
Code is based on this: https://learnopencv.com/optical-flow-in-opencv/
## Added:
- `convertFlowToColorMap()` which takes a flowX and flowY and outputs a color image in HSV color space as cv::mat bgr

## Updated:
- Included `convertFlowToColorMap()` into drivers

### To test rerun install and build VS solution
Run: `pixi run start`

### To test
Build and run `driverCPU.cu`, `driverGPU.cu`, or `driverGPUSharedMem.cu`

### Results
![image](https://github.com/user-attachments/assets/73bd87a3-b087-42af-bbd7-06b97f2a3564)


# TODO
- There is a lot of code duplication across the three drivers. Suggest combining the drivers back into one driver.cu with selectable implementations.
- The output of the optical flow image is not as expected. Some debugging of the driver and/or other components are needed.